### PR TITLE
spack support for NEST neural simulator

### DIFF
--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -30,6 +30,7 @@ case "$TRAVIS_OS_NAME" in
     linux)
         sudo apt-get update -q
         sudo apt-get install -y libgsl0-dev
+        sudo apt-get install -y cython
 
         # TODO: workaround for bug in Ubuntu 14.04
         # check https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1115466

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -9,6 +9,7 @@ case "$TRAVIS_OS_NAME" in
     osx)
         brew update > /dev/null
         brew install flex bison modules
+        brew install gsl
         brew tap homebrew/science
         brew install lmod
 
@@ -28,6 +29,7 @@ case "$TRAVIS_OS_NAME" in
 
     linux)
         sudo apt-get update -q
+        sudo apt-get install -y libgsl0-dev
 
         # TODO: workaround for bug in Ubuntu 14.04
         # check https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1115466

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -29,7 +29,7 @@ fi
 
 for package in "${packages[@]}"
 do
-    spack install $package
+    spack install -v $package
 
     # check if package installed properly
     if [[ `spack find $package` == *"No package matches"* ]];  then

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -8,6 +8,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
+        'nest'
         'neuron'
     )
 
@@ -18,6 +19,7 @@ else
     packages=(
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
+        'nest'
         'neuron'
     )
 

--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -40,6 +40,11 @@ packages:
             gsl@1.16: /usr
         buildable: False
         version: [1.16]
+    py-cython:
+        paths:
+            py-cython@0.20.1: /usr
+        buildable: False
+        version: [0.20.1]
     tau:
         variants: ~openmp ~comm ~phase
     coreneuron:

--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -35,6 +35,11 @@ packages:
             python@2.7: /usr
         version: [2.7]
         buildable: False
+    gsl:
+        paths:
+            gsl@1.16: /usr
+        buildable: False
+        version: [1.16]
     tau:
         variants: ~openmp ~comm ~phase
     coreneuron:

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -35,6 +35,11 @@ packages:
             python@2.7: /usr/local
         version: [2.7]
         buildable: False
+    gsl:
+        paths:
+            gsl@2.4: /usr/local
+        buildable: False
+        version: [2.4]
     tau:
         variants: ~openmp ~comm ~phase
     coreneuron:

--- a/packages/nest/package.py
+++ b/packages/nest/package.py
@@ -40,6 +40,7 @@
 from spack import *
 import string
 import os
+import subprocess
 
 
 class Nest(Package):
@@ -146,6 +147,9 @@ class Nest(Package):
             else:
                 cmake_options.extend(['-Dstatic-libraries=ON'])
 
+            if 'cray' in self.spec.architecture:
+                cmake_options.extend(['-Dwith-warning=OFF'])
+
             cmake('..', *cmake_options)
             self.profiling_wrapper_on()
             make()
@@ -165,5 +169,6 @@ class Nest(Package):
         # How to get python version specified by user???
         if self.spec.satisfies('+python'):
             py_version_string = 'python{0}'.format(self.spec['python'].version.up_to(2))
-            nest_package_py_path = os.path.join(self.prefix.lib64, py_version_string, 'site-packages')
+            nest_lib_dir = subprocess.check_output([self.prefix.bin + '/nest-config', '--libdir'])
+            nest_package_py_path = os.path.join(self.prefix, nest_lib_dir, py_version_string, 'site-packages')
             run_env.prepend_path('PYTHONPATH', nest_package_py_path)

--- a/packages/nest/package.py
+++ b/packages/nest/package.py
@@ -125,12 +125,12 @@ class Nest(Package):
                 cmake_options.extend(['-Dcythonize-pynest=OFF'])
             else:
                 cmake_options.extend(['-Dwith-python=ON'])
-                cmake_options.extend(['-Dcythonize-pynest=ON'])
+                cmake_options.extend(['-Dcythonize-pynest=%s' % self.spec['py-cython'].prefix])
 
             if self.spec.satisfies('~gsl'):
                 cmake_options.extend(['-Dwith-gsl=OFF'])
             else:
-                cmake_options.extend(['-Dwith-gsl=ON'])
+                cmake_options.extend(['-Dwith-gsl=%s' % self.spec['gsl'].prefix])
 
             if self.spec.satisfies('~mpi'):
                 cmake_options.extend(['-Dwith-mpi=OFF'])
@@ -169,6 +169,11 @@ class Nest(Package):
         # How to get python version specified by user???
         if self.spec.satisfies('+python'):
             py_version_string = 'python{0}'.format(self.spec['python'].version.up_to(2))
-            nest_lib_dir = subprocess.check_output([self.prefix.bin + '/nest-config', '--libdir'])
-            nest_package_py_path = os.path.join(self.prefix, nest_lib_dir, py_version_string, 'site-packages')
-            run_env.prepend_path('PYTHONPATH', nest_package_py_path)
+            try:
+#            print os.path.join( self.prefix.bin, 'nest-config')
+	        nest_lib_dir = subprocess.check_output([ os.path.join( self.prefix.bin, 'nest-config'), '--libdir'])
+#            print os.path.join(self.prefix, nest_lib_dir, py_version_string, 'site-packages')
+                nest_package_py_path = os.path.join(self.prefix, nest_lib_dir, py_version_string, 'site-packages')
+                run_env.prepend_path('PYTHONPATH', nest_package_py_path)
+            except OSError, e:
+                pass

--- a/packages/nest/package.py
+++ b/packages/nest/package.py
@@ -41,22 +41,25 @@ from spack import *
 import string
 import os
 
+
 class Nest(Package):
-    """FIXME: Put a proper description of your package here."""
+    """NEST is a simulator for spiking neural network models that focuses
+    on the dynamics, size and structure of neural systems rather than on
+    the exact morphology of individual neurons. The development of NEST
+    is coordinated by the NEST Initiative."""
 
     homepage = "https://github.com/nest/nest-simulator"
-    github_url      = "https://github.com/nest/nest-simulator.git"
+    url      = "https://github.com/nest/nest-simulator"
 
-    version('develop', git=github_url, preferred=True)
+    version('develop', git=url)
 
-    variant('mpi',           default=True,  description="Enable MPI support")
-    variant('openmp',        default=True,  description="Enable OpenMP support")
-    variant('python',        default=True,  description="Enable python bindings")
-    variant('gsl',           default=True,  description="Enable GNU Scientific Library")
-    variant('profile',       default=False, description="Enable profiling using Tau")
-    variant('knl',           default=False, description="Enable KNL specific flags")
-    variant('static',        default=False, description="Build static libraries")
-
+    variant('mpi',      default=True,  description="Enable MPI support")
+    variant('openmp',   default=True,  description="Enable OpenMP support")
+    variant('python',   default=True,  description="Enable python bindings")
+    variant('gsl',      default=True,  description="Enable GNU Scientific Library")
+    variant('profile',  default=False, description="Enable profiling using Tau")
+    variant('knl',      default=False, description="Enable KNL specific flags")
+    variant('static',   default=False, description="Build static libraries")
 
     depends_on('mpi', when='+mpi')
     depends_on('gsl', when='+gsl')
@@ -104,17 +107,16 @@ class Nest(Package):
                     cxx_compiler = self.spec['mpi'].mpicxx
 
             cmake_options = ['-DCMAKE_INSTALL_PREFIX:PATH=%s' % prefix,
-                       '-DCMAKE_C_FLAGS=%s' % optflag,
-                       '-DCMAKE_CXX_FLAGS=%s' % optflag,
-                       '-DCMAKE_C_COMPILER=%s' % c_compiler,
-                       '-DCMAKE_CXX_COMPILER=%s' % cxx_compiler,
-                       '-Dwith-ltdl=OFF',
-                       '-Dwith-readline=OFF'
-                       ]
+                             '-DCMAKE_C_FLAGS=%s' % optflag,
+                             '-DCMAKE_CXX_FLAGS=%s' % optflag,
+                             '-DCMAKE_C_COMPILER=%s' % c_compiler,
+                             '-DCMAKE_CXX_COMPILER=%s' % cxx_compiler,
+                             '-Dwith-ltdl=OFF',
+                             '-Dwith-readline=OFF']
 
             # not sure the -Dwith-optimize=flags option is required if we already set CMAKE_C_FLAGS above
             # but just to be safe
-            semicolon_separated_optflag = optflag.translate(string.maketrans(' ',';'))
+            semicolon_separated_optflag = optflag.translate(string.maketrans(' ', ';'))
             cmake_options.extend(['-Dwith-optimize=' + semicolon_separated_optflag])
 
             if self.spec.satisfies('~python'):
@@ -161,17 +163,7 @@ class Nest(Package):
         # I wish there was a way to detect the specs here.
         # If the user didn't want python, no need to pollute their env.
         # How to get python version specified by user???
-        if not self.spec.satisfies('~python'):
+        if self.spec.satisfies('+python'):
             py_version_string = 'python{0}'.format(self.spec['python'].version.up_to(2))
             nest_package_py_path = os.path.join(self.prefix.lib64, py_version_string, 'site-packages')
-            print('PYTHONPATH')
-            print(nest_package_py_path)
             run_env.prepend_path('PYTHONPATH', nest_package_py_path)
-
-
-
-
-
-
-
-

--- a/packages/nest/package.py
+++ b/packages/nest/package.py
@@ -1,0 +1,177 @@
+##############################################################################
+# Copyright (c) 2013-2016, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/llnl/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install nest
+#
+# You can edit this file again by typing:
+#
+#     spack edit nest
+#
+# See the Spack documentation for more information on packaging.
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+from spack import *
+import string
+import os
+
+class Nest(Package):
+    """FIXME: Put a proper description of your package here."""
+
+    homepage = "https://github.com/nest/nest-simulator"
+    github_url      = "https://github.com/nest/nest-simulator.git"
+
+    version('develop', git=github_url, preferred=True)
+
+    variant('mpi',           default=True,  description="Enable MPI support")
+    variant('openmp',        default=True,  description="Enable OpenMP support")
+    variant('python',        default=True,  description="Enable python bindings")
+    variant('gsl',           default=True,  description="Enable GNU Scientific Library")
+    variant('profile',       default=False, description="Enable profiling using Tau")
+    variant('knl',           default=False, description="Enable KNL specific flags")
+    variant('static',        default=False, description="Build static libraries")
+
+
+    depends_on('mpi', when='+mpi')
+    depends_on('gsl', when='+gsl')
+    depends_on('python@2.6:', when='+python')
+    depends_on('cmake@2.8.12:', type='build')
+    depends_on('tau', when='+profile')
+    depends_on('py-cython@0.19.2:', when='+python')
+
+    def profiling_wrapper_on(self):
+        if self.spec.satisfies('+profile'):
+            os.environ["USE_PROFILER_WRAPPER"] = "1"
+
+    def profiling_wrapper_off(self):
+        if self.spec.satisfies('+profile'):
+            del os.environ["USE_PROFILER_WRAPPER"]
+
+    def get_optimization_level(self):
+        flags = "-g"
+
+        if 'bgq' in self.spec.architecture:
+            flags += ' -O3'
+        else:
+            flags += ' -O2'
+
+        if self.spec.satisfies('+knl'):
+            flags = '-g -xmic-avx512 -O3 -qopt-report=5'
+
+        return flags
+
+    def install(self, spec, prefix):
+        build_dir = "spack-build-%s" % spec.version
+
+        with working_dir(build_dir, create=True):
+            c_compiler = spack_cc
+            cxx_compiler = spack_cxx
+
+            optflag = self.get_optimization_level()
+
+            if self.spec.satisfies('+profile'):
+                c_compiler = 'tau_cc'
+                cxx_compiler = 'tau_cxx'
+            # for bg-q, our cmake is not setup properly
+            elif 'bgq' in self.spec.architecture and self.spec.satisfies('+mpi'):
+                    c_compiler = self.spec['mpi'].mpicc
+                    cxx_compiler = self.spec['mpi'].mpicxx
+
+            cmake_options = ['-DCMAKE_INSTALL_PREFIX:PATH=%s' % prefix,
+                       '-DCMAKE_C_FLAGS=%s' % optflag,
+                       '-DCMAKE_CXX_FLAGS=%s' % optflag,
+                       '-DCMAKE_C_COMPILER=%s' % c_compiler,
+                       '-DCMAKE_CXX_COMPILER=%s' % cxx_compiler,
+                       '-Dwith-ltdl=OFF',
+                       '-Dwith-readline=OFF'
+                       ]
+
+            # not sure the -Dwith-optimize=flags option is required if we already set CMAKE_C_FLAGS above
+            # but just to be safe
+            semicolon_separated_optflag = optflag.translate(string.maketrans(' ',';'))
+            cmake_options.extend(['-Dwith-optimize=' + semicolon_separated_optflag])
+
+            if self.spec.satisfies('~python'):
+                cmake_options.extend(['-Dwith-python=OFF'])
+                cmake_options.extend(['-Dcythonize-pynest=OFF'])
+            else:
+                cmake_options.extend(['-Dwith-python=ON'])
+                cmake_options.extend(['-Dcythonize-pynest=ON'])
+
+            if self.spec.satisfies('~gsl'):
+                cmake_options.extend(['-Dwith-gsl=OFF'])
+            else:
+                cmake_options.extend(['-Dwith-gsl=ON'])
+
+            if self.spec.satisfies('~mpi'):
+                cmake_options.extend(['-Dwith-mpi=OFF'])
+            else:
+                cmake_options.extend(['-Dwith-mpi=ON'])
+
+            if self.spec.satisfies('~openmp'):
+                cmake_options.extend(['-Dwith-openmp=OFF'])
+            else:
+                cmake_options.extend(['-Dwith-openmp=ON'])
+
+            if self.spec.satisfies('~static'):
+                cmake_options.extend(['-Dstatic-libraries=OFF'])
+            else:
+                cmake_options.extend(['-Dstatic-libraries=ON'])
+
+            cmake('..', *cmake_options)
+            self.profiling_wrapper_on()
+            make()
+            make('install')
+            self.profiling_wrapper_off()
+
+    def setup_environment(self, spack_env, run_env):
+        exe = '%s/nest' % self.prefix.bin
+        run_env.set('NEST_EXE', exe)
+
+        # for mvapich2 module we need to setup MV2_ENABLE_AFFINITY
+        # env variable to turn on multi-threading support
+        run_env.set('MV2_ENABLE_AFFINITY', '0')
+
+        # I wish there was a way to detect the specs here.
+        # If the user didn't want python, no need to pollute their env.
+        # How to get python version specified by user???
+        if not self.spec.satisfies('~python'):
+            py_version_string = 'python{0}'.format(self.spec['python'].version.up_to(2))
+            nest_package_py_path = os.path.join(self.prefix.lib64, py_version_string, 'site-packages')
+            print('PYTHONPATH')
+            print(nest_package_py_path)
+            run_env.prepend_path('PYTHONPATH', nest_package_py_path)
+
+
+
+
+
+
+
+

--- a/packages/nest/package.py
+++ b/packages/nest/package.py
@@ -94,6 +94,12 @@ class Nest(Package):
             semicolon_separated_optflag = optflag.translate(string.maketrans(' ', ';'))
             cmake_options.append('-Dwith-optimize=%s' % semicolon_separated_optflag)
 
+            if 'bgq' in spec.architecture:
+                cmake_options.append('-Denable-bluegene=Q')
+                # sli exe link line needs qnostatic when +shared
+                if spec.satisfies('+shared'):
+                    cmake_options.append('-DCMAKE_EXE_LINKER_FLAGS=-qnostaticlink')
+
             if spec.satisfies('+python'):
                 cmake_options.extend(['-Dwith-python=ON',
                                       '-Dcythonize-pynest=%s' % spec['py-cython'].prefix])


### PR DESCRIPTION
Adding possibility to compile [NEST](http://www.nest-simulator.org/) from their github repository. 

For the moment, I tested on viz cluster and it works. Will push fixes as we test other architectures.

Supports python, mpi, and the tau-profiler stack in the same way that coreneuron does. When python is enabled, it automatically appends the correct PYTHONPATH when the module is loaded. 