### PR TITLE
Fix #7 : avoid spack compiler wrappers getting embedded into

### DIFF
--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -294,6 +294,22 @@ class Neuron(Package):
             make('install')
             self.profiling_wrapper_off()
 
+    @run_after('install')
+    def filter_compilers(self):
+        """run after install to avoid spack compiler wrappers
+        getting embded into nrnivmodl script"""
+
+        arch = self.get_neuron_arch_dir()
+        nrnmakefile = join_path(self.prefix, arch, 'bin/nrniv_makefile')
+
+        kwargs = {
+            'backup': False,
+            'string': True
+        }
+
+        filter_file(env['CC'],  self.compiler.cc, nrnmakefile, **kwargs)
+        filter_file(env['CXX'], self.compiler.cxx, nrnmakefile, **kwargs)
+
     def setup_environment(self, spack_env, run_env):
         arch = self.get_neuron_arch_dir()
         run_env.prepend_path('PATH', join_path(self.prefix, arch, 'bin'))


### PR DESCRIPTION
nrnivmodl as it used by users as compiler for mod files.

FYI @sharkovsky 

On Piz Daint it builds now fine:

```
$ nrnivmodl -loadflags "-dynamic" .
/users/kumbhar/workarena/systems/daint/bbp/repos/nrnperfmodels/neuron_mod
ls: cannot access ./*.inc: No such file or directory
./exp2syn.mod
exp2syn.mod
cc -DHAVE_CONFIG_H -I. -I.. -I/users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/include/nrn -I/users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib     -O2 -g  -c mod_func.c
/users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/share/nrn/libtool --tag=CC --mode=link CC  -O2 -g  -dynamic  -o special /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/nrnmain.o /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/ivocmain.o /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/nvkludge.o exp2syn.o mod_func.o  -L/users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib -lnrnoc -loc -lnrniv -livoc -loc -lneuron_gnu -lscopmath -lsparse13 -lsundials -lnrnmpi -lmeschach -livos     -lnrnpython -L/apps/daint/UES/jenkins/6.0.UP02/mc/easybuild/software/Python/2.7.12-CrayGNU-2016.11/lib -lpython2.7      -lmpich -lm -ldl
libtool: link: CC -O2 -g -dynamic -o special /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/nrnmain.o /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/ivocmain.o /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/nvkludge.o exp2syn.o mod_func.o  -L/users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libnrnoc.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libnrniv.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libivoc.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/liboc.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libneuron_gnu.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libscopmath.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libsparse13.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libsundials.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libnrnmpi.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libmeschach.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libivos.a /users/kumbhar/workarena/systems/daint/softwares/sources/spack/opt/spack/cray-CNL-haswell/gcc-4.9.3/neuron-master-gxn4w2omwg37lauinwb45sylzzgbml7m/x86_64/lib/libnrnpython.a /opt/gcc/4.9.3/snos/lib/../lib64/libgfortran.so /opt/gcc/4.9.3/snos/lib/../lib64/libquadmath.so /opt/gcc/4.9.3/snos/lib/../lib64/libstdc++.so -L/apps/daint/UES/jenkins/6.0.UP02/mc/easybuild/software/Python/2.7.12-CrayGNU-2016.11/lib -lpython2.7 -lmpich -lm -ldl -Wl,-rpath -Wl,/opt/gcc/4.9.3/snos/lib/../lib64 -Wl,-rpath -Wl,/opt/gcc/4.9.3/snos/lib/../lib64
Successfully created x86_64/special
```