### PR TITLE
Add NEURON ncurses dependency

### DIFF
--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -44,6 +44,7 @@ class Neuron(Package):
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('libtool', type='build')
+    depends_on('ncurses')
     depends_on("nrnh5", when='@hdf')
     depends_on('python@2.6:', when='+python')
     depends_on('tau', when='+profile')


### PR DESCRIPTION
Before merge we have to make sure to update `packages.yaml` on  all platform (to avoid building ncurses because all platforms have it except multi-arch issue on Julia)