### PR TITLE
When external python was specified was module or path,

### DIFF
--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -61,4 +61,3 @@ esac
 # print python paths in case we need for debugging
 python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
 python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"
-ls -l /opt/python/3.5.3/lib/* || ls

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -12,7 +12,7 @@ case "$TRAVIS_OS_NAME" in
         brew install gsl
         brew tap homebrew/science
         brew install lmod
-        brew install python3
+        #brew install python3
 
         ls /usr/bin/python* /usr/local/bin/python*
 

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -14,11 +14,6 @@ case "$TRAVIS_OS_NAME" in
         brew install lmod
         brew install python3
 
-        ls /usr/bin/python* /usr/local/bin/python*
-
-        python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
-        python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"
-
         case "$MPI_LIB_NAME" in
             mpich|mpich3)
                 brew install mpich
@@ -37,6 +32,7 @@ case "$TRAVIS_OS_NAME" in
         sudo apt-get update -q
         sudo apt-get install -y libgsl0-dev
         sudo apt-get install -y cython
+        sudo apt-get install -y libpython3-dev
 
         # TODO: workaround for bug in Ubuntu 14.04
         # check https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/1115466
@@ -61,3 +57,8 @@ case "$TRAVIS_OS_NAME" in
         exit 1
         ;;
 esac
+
+ls /usr/bin/python* /usr/local/bin/python*
+
+python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
+python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -12,7 +12,7 @@ case "$TRAVIS_OS_NAME" in
         brew install gsl
         brew tap homebrew/science
         brew install lmod
-        #brew install python3
+        brew install python3
 
         ls /usr/bin/python* /usr/local/bin/python*
 

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -58,7 +58,6 @@ case "$TRAVIS_OS_NAME" in
         ;;
 esac
 
-ls /usr/bin/python* /usr/local/bin/python*
-
+# print python paths in case we need for debugging
 python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
 python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -13,6 +13,8 @@ case "$TRAVIS_OS_NAME" in
         brew tap homebrew/science
         brew install lmod
 
+        python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
+
         case "$MPI_LIB_NAME" in
             mpich|mpich3)
                 brew install mpich

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -61,3 +61,4 @@ esac
 # print python paths in case we need for debugging
 python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
 python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"
+ls -l /opt/python/3.5.3/lib/* || ls

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -12,8 +12,12 @@ case "$TRAVIS_OS_NAME" in
         brew install gsl
         brew tap homebrew/science
         brew install lmod
+        brew install python3
+
+        ls /usr/bin/python* /usr/local/bin/python*
 
         python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
+        python3 -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
 
         case "$MPI_LIB_NAME" in
             mpich|mpich3)

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -17,7 +17,7 @@ case "$TRAVIS_OS_NAME" in
         ls /usr/bin/python* /usr/local/bin/python*
 
         python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
-        python3 -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')"
+        python3 -c "import sysconfig; print (sysconfig.get_config_var('LIBDIR'))"
 
         case "$MPI_LIB_NAME" in
             mpich|mpich3)

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,11 +6,11 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
+        'nest +python ^python@2.7.13'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.5.3'
         'neuron +python ^python@2.7.13'
-        'nest'
     )
 
     # for module support on linux
@@ -18,11 +18,11 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
+        'nest +python ^python@2.7.12'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.6.2'
         'neuron +python ^python@2.7.12'
-        'nest'
     )
 
     # for module support on osx

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-#set -e
+set -e
 
 # the list of packages for linux and osx could be different
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
+        'mod2c'
+        'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.5.3'
         'neuron +python ^python@2.7.13'
-        #'mod2c'
-        #'coreneuron ~neurodamusmod ~report'
-        #'nest'
+        'nest'
     )
 
     # for module support on linux
@@ -18,22 +18,22 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
+        'mod2c'
+        'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.6.2'
         'neuron +python ^python@2.7.12'
-        #'mod2c'
-        #'coreneuron ~neurodamusmod ~report'
-        #'nest'
+        'nest'
     )
 
     # for module support on osx
     source /usr/local/opt/modules/Modules/init/bash;
 fi
 
+# NOTE : if configure fails we have to get use something like below to print log
+#           find /tmp/travis/spack-stage -name 'config.log' -exec cat {} \;
 for package in "${packages[@]}"
 do
     spack install -v $package
-
-    find /tmp/travis/spack-stage -name 'config.log' -exec cat {} \;
 
     # check if package installed properly
     if [[ `spack find $package` == *"No package matches"* ]];  then
@@ -46,6 +46,12 @@ do
 done
 
 source $SPACK_ROOT/share/spack/setup-env.sh
+# show available modules
 module av
-spack load mod2c
+
+# show all dependency
+spack find -d
+
+# load one of the module
+spack load neuron
 module list

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,7 +6,7 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
-        'nest +python ^python@2.7.13'
+        'nest -python'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.5.3'
@@ -18,7 +18,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
-        'nest +python ^python@2.7.12'
+        'nest -python'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.6.2'

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+#set -e
 
 # the list of packages for linux and osx could be different
 
@@ -32,6 +32,8 @@ fi
 for package in "${packages[@]}"
 do
     spack install -v $package
+
+    find /tmp/travis/spack-stage -name 'config.log' -exec cat {} \;
 
     # check if package installed properly
     if [[ `spack find $package` == *"No package matches"* ]];  then

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,8 +6,8 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
-        'neuron +python ^python@3.4.0'
-        'neuron +python ^python@2.7'
+        'neuron +python ^python@3.5.3'
+        'neuron +python ^python@2.7.13'
         #'mod2c'
         #'coreneuron ~neurodamusmod ~report'
         #'nest'
@@ -19,7 +19,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 else
     packages=(
         'neuron +python ^python@3.6.2'
-        'neuron +python ^python@2.7'
+        'neuron +python ^python@2.7.12'
         #'mod2c'
         #'coreneuron ~neurodamusmod ~report'
         #'nest'

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,10 +6,11 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
-        'neuron'
-        'mod2c'
-        'coreneuron ~neurodamusmod ~report'
-        'nest'
+        'neuron +python ^python@3.4.0'
+        'neuron +python ^python@2.7'
+        #'mod2c'
+        #'coreneuron ~neurodamusmod ~report'
+        #'nest'
     )
 
     # for module support on linux
@@ -19,9 +20,9 @@ else
     packages=(
         'neuron +python ^python@3.6.2'
         'neuron +python ^python@2.7'
-        'mod2c'
-        'coreneuron ~neurodamusmod ~report'
-        'nest'
+        #'mod2c'
+        #'coreneuron ~neurodamusmod ~report'
+        #'nest'
     )
 
     # for module support on osx

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -17,7 +17,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
-        'neuron'
+        'neuron +python ^python@3.6.2'
+        'neuron +python ^python@2.7'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'nest'

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,10 +6,10 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
+        'neuron'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'nest'
-        'neuron'
     )
 
     # for module support on linux
@@ -17,10 +17,10 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
+        'neuron'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'nest'
-        'neuron'
     )
 
     # for module support on osx

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -6,11 +6,11 @@ set -e
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     packages=(
-        'nest -python'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.5.3'
         'neuron +python ^python@2.7.13'
+        'nest -python'
     )
 
     # for module support on linux
@@ -18,11 +18,11 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
 else
     packages=(
-        'nest -python'
         'mod2c'
         'coreneuron ~neurodamusmod ~report'
         'neuron +python ^python@3.6.2'
         'neuron +python ^python@2.7.12'
+        'nest -python'
     )
 
     # for module support on osx

--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -38,7 +38,8 @@ packages:
     python:
         paths:
             python@2.7: /usr
-        version: [2.7]
+            python@3.4.0: /usr
+        version: [2.7, 3.4.0]
         buildable: False
     gsl:
         paths:

--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -37,9 +37,9 @@ packages:
         version: [system]
     python:
         paths:
-            python@2.7: /usr
-            python@3.4.0: /usr
-        version: [2.7, 3.4.0]
+            python@2.7.13: /opt/python/2.7.13
+            python@3.5.3: /opt/python/3.5.3
+        version: [2.7.13, 3.5.3]
         buildable: False
     gsl:
         paths:

--- a/.travis/packages.linux.yaml
+++ b/.travis/packages.linux.yaml
@@ -5,6 +5,11 @@ packages:
             mpich@3.0.4: /usr
         version: [3.0.4]
         buildable: False
+    openmpi:
+        paths:
+            openmpi@2.1.1: /usr
+        buildable: False
+        version: [2.1.1]
     cmake:
         paths:
             cmake@3.2.2: /usr

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -38,7 +38,7 @@ packages:
     python:
         paths:
             python@2.7: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6.2: /usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib
+            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
         version: [2.7, 3.6.2]
         buildable: False
     gsl:

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -38,7 +38,7 @@ packages:
     python:
         paths:
             python@2.7: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
+            python@3.6.2: /usr/local/opt/python3/Frameworks/Python.framework/Versions/3.6/lib
         version: [2.7, 3.6.2]
         buildable: False
     gsl:

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -5,6 +5,11 @@ packages:
             mpich@3.0.4: /usr/local
         version: [3.0.4]
         buildable: False
+    openmpi:
+        paths:
+            openmpi@2.1.1: /usr/local
+        buildable: False
+        version: [2.1.1]
     cmake:
         paths:
             cmake@3.6.2: /usr/local
@@ -32,7 +37,7 @@ packages:
         version: [system]
     python:
         paths:
-            python@2.7: /usr/local
+            python@2.7: /System/Library/Frameworks/Python.framework/Versions/2.7
         version: [2.7]
         buildable: False
     gsl:

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -37,9 +37,9 @@ packages:
         version: [system]
     python:
         paths:
-            python@2.7: /System/Library/Frameworks/Python.framework/Versions/2.7
+            python@2.7.12: /System/Library/Frameworks/Python.framework/Versions/2.7
             python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
-        version: [2.7, 3.6.2]
+        version: [2.7.12, 3.6.2]
         buildable: False
     gsl:
         paths:

--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -38,7 +38,8 @@ packages:
     python:
         paths:
             python@2.7: /System/Library/Frameworks/Python.framework/Versions/2.7
-        version: [2.7]
+            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
+        version: [2.7, 3.6.2]
         buildable: False
     gsl:
         paths:

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -140,11 +140,10 @@ class Neuron(Package):
             py_lib_dir = spec['python'].prefix.lib
             extra_libs = ''
 
-            # todo : bit of hack for argonne systems because they have differnt
-            #        installation structure compared to other systems. Doing
-            #        this temporarily to get production runs going.
+            # todo : bit of hack for argonne bgq system as they have extra
+            #        libraries to link. May be adding variant would be better?
             import socket
-            if 'alcf.anl.gov' in socket.getfqdn():
+            if 'bgq' in spec.architecture and 'alcf.anl.gov' in socket.getfqdn():
                 extra_libs = '-lz -lssl -lcrypto -lutil'
 
             # on platform like theta cray, intel python has extra directory include/python3.5m/

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -132,37 +132,35 @@ class Neuron(Package):
 
             options.extend(['--with-nrnpython=%s' % python_exec, '--disable-pysetup'])
 
-            if spec.satisfies('+cross-compile'):
+	    py_lib = spec['python'].prefix.lib
+	    py_lib_64 = spec['python'].prefix.lib64
+	    py_inc_dir = '%s/include/%s' % (py_prefix, py_version_string)
+	    extra_libs = ''
 
-                py_lib = spec['python'].prefix.lib
-                py_lib_64 = spec['python'].prefix.lib64
-                py_inc_dir = '%s/include/%s' % (py_prefix, py_version_string)
-                extra_libs = ''
+	    if not os.path.isdir(py_lib):
+		py_lib = py_lib_64
 
-                if not os.path.isdir(py_lib):
-                    py_lib = spec['python'].prefix.lib
+	    # todo : bit of hack for argonne systems because they have differnt
+	    #        installation structure compared to other systems. Doing
+	    #        this temporarily to get production runs going.
+	    import socket
+	    if 'alcf.anl.gov' in socket.getfqdn():
+		extra_libs = '-lz -lssl -lcrypto -lutil'
+	    elif 'thetalog' in socket.getfqdn():
+		# another hack for theta until sysadmins fix the permissions! :(
+		# need to cleanup this soon!
+		if spec.satisfies('^python@3.5'):
+		    py_version_string = 'python3.5m'
 
-                # todo : bit of hack for argonne systems because they have differnt
-                #        installation structure compared to other systems. Doing
-                #        this temporarily to get production runs going.
-                import socket
-                if 'alcf.anl.gov' in socket.getfqdn():
-                    extra_libs = '-lz -lssl -lcrypto -lutil'
-                elif 'thetalog' in socket.getfqdn():
-                    # another hack for theta until sysadmins fix the permissions! :(
-                    # need to cleanup this soon!
-                    if spec.satisfies('^python@3.5'):
-                        py_version_string = 'python3.5m'
+		# on platform like theta cray, intel python has extra directory include/python3.5m/
+		# find directory of Python.h
+		python_h_file = [y for x in os.walk(py_prefix) for y in glob.glob(os.path.join(x[0], 'Python.h'))][0]
+		py_inc_dir = os.path.dirname(python_h_file)
 
-                    # on platform like theta cray, intel python has extra directory include/python3.5m/
-                    # find directory of Python.h
-                    python_h_file = [y for x in os.walk(py_prefix) for y in glob.glob(os.path.join(x[0], 'Python.h'))][0]
-                    py_inc_dir = os.path.dirname(python_h_file)
-
-                options.extend(['PYINCDIR=%s' % (py_inc_dir),
-                                'PYLIB=-L%s -l%s %s' % (py_lib, py_version_string, extra_libs),
-                                'PYLIBDIR=%s' % py_lib,
-                                'PYLIBLINK=-L%s -L%s -l%s %s' % (py_lib, py_lib_64, py_version_string, extra_libs)])
+	    options.extend(['PYINCDIR=%s' % (py_inc_dir),
+			    'PYLIB=-L%s -l%s %s' % (py_lib, py_version_string, extra_libs),
+			    'PYLIBDIR=%s' % py_lib,
+			    'PYLIBLINK=-L%s -L%s -l%s %s' % (py_lib, py_lib_64, py_version_string, extra_libs)])
         else:
             options.extend(['--without-nrnpython'])
         return options


### PR DESCRIPTION
NEURON was not able to figure out libraries correctly (in certain scenarios). Use logic from cross compilation process to correctly provide all paths (tested on JURON & JULIA)