### PR TITLE
Set PYTHONPATH for NEURON when compiled with +python

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -60,8 +60,8 @@ function install_packages {
             spack spec -I $full_spec
 
             # install package
-            echo " == > INSTALLING PACKAGE : spack install $install_options $full_spec"
-            spack install $install_options $full_spec
+            echo " == > INSTALLING PACKAGE : spack install $opts $full_spec"
+            spack install $opts $full_spec
 
             # if there is no matching package then show build log
             if [[ `spack find $full_spec` == *"No package matches"* ]]; then
@@ -118,7 +118,7 @@ install_packages
 
 
 ########################################## SPACK INSTALL OPTIONS ########################################
-install_options='--dirty --log-format=junit'
+opts='--dirty --show-log-on-error'
 
 
 ############################################ REGISTER PACKAGES ###########################################

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -13,6 +13,12 @@ case "$TRAVIS_OS_NAME" in
         brew tap homebrew/science
         brew install python3
 
+        # NOTE: brew installed python3 on OSX has known issue
+        # See https://stackoverflow.com/questions/24257803/
+        rm -f ~/.pydistutils.cfg
+        echo "[install]" > ~/.pydistutils.cfg
+        echo "prefix=" >> ~/.pydistutils.cfg
+
         case "$MPI_LIB_NAME" in
             mpich|mpich3)
                 brew install mpich

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -7,18 +7,22 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
                 'mod2c'
                 'coreneuron ~neurodamusmod ~report'
                 'coreneuron ~neurodamusmod ~report ~mpi'
-                'neuron@develop +python ^python@3'
-                'neuron@develop +python ^python@2.7'
-                'neuron@develop -python'
-                'neuron@develop +shared -mpi'
+                'neuron@develop +python +shared ^python@3'
+                'neuron@develop +python +shared ^python@2.7'
+                'neuron@develop +python -shared ^python@2.7'
+                'neuron@develop +python -shared ^python@3'
+                'neuron@develop -python -shared -mpi'
         )
 # for PRs do minumum builds
 else
         packages=(
                 'coreneuron ~neurodamusmod ~report'
                 'coreneuron ~neurodamusmod ~report ~mpi'
-                'neuron@develop +shared ~mpi'
-                'neuron@develop +python ^python@2.7'
+                'neuron@develop +python +shared ^python@3'
+                'neuron@develop +python +shared ^python@2.7'
+                'neuron@develop +python -shared ^python@2.7'
+                'neuron@develop +python -shared ^python@3'
+                'neuron@develop -python -shared -mpi'
         )
 fi
 

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -52,13 +52,12 @@ do
     spack spec -I $package
 
     # install package
-    (spack install $package; exit 0)
+    spack install --show-log-on-error $package
 
     # check if package installed properly
     if [[ `spack find $package` == *"No package matches"* ]];  then
 
-        echo " == > PACKAGE INSTALLATION CHECK FAILED, BUILD LOG : "
-        cat `spack location $package`/spack-build.out
+        echo " == > PACKAGE INSTALLATION CHECK FAILED!"
         exit 1
 
     fi

--- a/packages/neurodamus/package.py
+++ b/packages/neurodamus/package.py
@@ -44,6 +44,7 @@ class Neurodamus(Package):
     depends_on("hdf5", when='+compile')
     depends_on("zlib", when='+compile')
     depends_on("neuron", when='+compile')
+    depends_on("neuron~shared", when='+compile+profile')
     depends_on("mpi", when='+compile')
     depends_on('reportinglib', when='+compile')
 

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -123,7 +123,7 @@ class Neuron(Package):
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 
-            if spec.satisfies('+cross-compile') or spec.satisfies('~shared'):
+            if spec.satisfies('+cross-compile') or spec.satisfies('~shared') or spec.satisfies('+profile'):
                 options.append('--disable-pysetup')
             else:
                 options.append('PYTHON_BLD=%s' % python_exec)

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -48,7 +48,7 @@ class Neuron(Package):
 
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('python',        default=True,  description='Enable python')
-    variant('shared',        default=False, description='Build shared libraries')
+    variant('shared',        default=True,  description='Build shared libraries')
     variant('cross-compile', default=False, description='Build for cross-compile environment')
     variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
     variant('profile',       default=False, description="Enable Tau profiling")

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -123,7 +123,7 @@ class Neuron(Package):
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 
-            if spec.satisfies('+cross-compile'):
+            if spec.satisfies('+cross-compile') or spec.satisfies('~shared'):
                 options.append('--disable-pysetup')
             else:
                 options.append('PYTHON_BLD=%s' % python_exec)

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -120,11 +120,12 @@ class Neuron(Package):
                 py_lib = spec['python'].prefix.lib64
 
             options.extend(['--with-nrnpython=%s' % python_exec,
-                            '--disable-pysetup',
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 
-            if spec.satisfies('~cross-compile'):
+            if spec.satisfies('+cross-compile'):
+                options.append('--disable-pysetup')
+            else:
                 options.append('PYTHON_BLD=%s' % python_exec)
 
             # TODO : neuron has depdendency with backend python as well as front-end
@@ -248,6 +249,12 @@ class Neuron(Package):
     def setup_environment(self, spack_env, run_env):
         arch = self.get_arch_dir()
         run_env.prepend_path('PATH', join_path(self.prefix, arch, 'bin'))
+
+        if self.spec.satisfies('+python'):
+            eggs = find(self.prefix, 'NEURON*egg*')
+            if eggs:
+                site_packages = os.path.dirname(find(self.prefix, 'NEURON*egg*')[0])
+                run_env.prepend_path('PYTHONPATH', site_packages)
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         arch = self.get_arch_dir()

--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -123,10 +123,11 @@ class Neuron(Package):
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 
-            if spec.satisfies('+cross-compile') or spec.satisfies('~shared') or spec.satisfies('+profile'):
-                options.append('--disable-pysetup')
-            else:
+            if spec.satisfies('~cross-compile'):
                 options.append('PYTHON_BLD=%s' % python_exec)
+
+            if spec.satisfies('+cross-compile') or spec.satisfies('~shared') or spec.satisfies('%pgi'):
+                options.append('--disable-pysetup')
 
             # TODO : neuron has depdendency with backend python as well as front-end
             # while building for python3 we see issue because neuron use python from

--- a/packages/neuronperfmodels/package.py
+++ b/packages/neuronperfmodels/package.py
@@ -33,7 +33,7 @@ class Neuronperfmodels(Package):
     depends_on('reportinglib',  when='@neuron')
     depends_on('reportinglib+profile',  when='@neuron+profile')
     depends_on('neuron', when='@neuron')
-    depends_on('neuron+profile', when='@neuron+profile')
+    depends_on('neuron~shared+profile', when='@neuron+profile')
     depends_on('hdf5', when='@neuron')
     depends_on('zlib', when='@neuron')
     depends_on('mpi', when='@neuron')

--- a/sysconfigs/julia/modules.yaml
+++ b/sysconfigs/julia/modules.yaml
@@ -1,10 +1,9 @@
 modules:
-
   enable::
       - tcl
-
   tcl:
     all:
+      autoload: 'direct'
       suffixes:
           '^intelmpi': 'intelmpi'
       conflict:
@@ -14,4 +13,4 @@ modules:
           '${PACKAGE}_ROOT': '${PREFIX}'
     hash_length: 0
     naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}'
-    blacklist: ['pdt', 'hdf5', 'zlib', 'autoconf', 'libtool', 'pkg-config', 'cmake', 'automake']
+    blacklist: ['pdt', 'hdf5', 'zlib', 'autoconf', 'libtool', 'pkg-config', 'cmake', 'automake', 'flex', 'bison']

--- a/sysconfigs/julia/packages.yaml
+++ b/sysconfigs/julia/packages.yaml
@@ -57,13 +57,8 @@ packages:
         version: [1.8.16]
     zlib:
         version: [1.2.8]
-
     tau:
         variants: ~openmp ~comm ~phase
-
-    neuron:
-        variants: ~python
-
     all:
         compiler: [intel]
         providers:

--- a/sysconfigs/juron/modules.yaml
+++ b/sysconfigs/juron/modules.yaml
@@ -5,6 +5,7 @@ modules:
 
   tcl:
     all:
+      autoload: 'direct'
       suffixes:
           '^openmpi': 'openmpi'
       conflict:
@@ -14,4 +15,4 @@ modules:
           '${PACKAGE}_ROOT': '${PREFIX}'
     hash_length: 4
     naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}'
-    blacklist: ['pdt', 'hdf5', 'zlib', 'autoconf', 'libtool', 'pkg-config', 'cmake', 'automake', 'python']
+    blacklist: ['pdt', 'hdf5', 'zlib', 'autoconf', 'libtool', 'pkg-config', 'cmake', 'automake', 'python', 'flex', 'bison']

--- a/sysconfigs/juron/packages.yaml
+++ b/sysconfigs/juron/packages.yaml
@@ -65,10 +65,6 @@ packages:
 
     tau:
         variants: ~openmp ~comm ~phase
-
-    neuron:
-        variants: ~python
-
     all:
         compiler: [xl@14.1]
         providers:


### PR DESCRIPTION
Fix #58.

@wvangeit : I was bit conservative and using `disable-pysetup` option. Especially considering cross-compiling architectures where we have weird setup of Python.

This should now set correct PYTHONPATH. I am searching for egg file and then use that as directory name. Note that we build `static` libraries by default (considering bg-q system). I think I should change this considering most people will need shared libraries. Today I do:

```
spack install neuron@develop +python +shared
```

P.S. Spack uses modules underneath and create automatically. So if we look at generated modules we see that there was no PYTHONPATH:

![neuron_no_py_path](https://user-images.githubusercontent.com/27898197/30814281-fe475c54-a20f-11e7-8a5e-278982ad1c0f.png)

This PR should fix this:

![neuron_py_path](https://user-images.githubusercontent.com/27898197/30814352-2eb752e0-a210-11e7-946a-db76043755af.png)
