### PR TITLE
Refactoring variants naming for neurodamus and reporting lib

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -78,7 +78,10 @@ function install_packages {
 gcc_package_group=(
   'neuron ~shared ~python ~mpi'
   'neuron +shared +python +mpi'
-  'neurodamus@master +compile'
+  'neurodamus@master +special'
+  'neurodamus@coreneuron +special'
+  'neurodamus@plasticity +special'
+  'neurodamus@hippocampus +special'
   'coreneuron ~mpi'
   'coreneuron +mpi'
   'nest@develop +python'
@@ -88,6 +91,7 @@ gcc_package_group=(
 gcc_intel_pgi_package_group=(
   'neuronperfmodels@neuron'
   'coreneuron@perfmodels +mpi'
+  'coreneuron ~neurodamus +mpi'
   'neuronperfmodels@neuron +profile'
   'coreneuron@perfmodels +profile +mpi'
 )

--- a/.install.sh
+++ b/.install.sh
@@ -78,7 +78,7 @@ function install_packages {
 gcc_package_group=(
   'neuron ~shared ~python ~mpi'
   'neuron +shared +python +mpi'
-  'neurodamus@master +compile'
+  'neurodamus@master +special'
   'coreneuron ~mpi'
   'coreneuron +mpi'
   'nest@develop +python'
@@ -88,6 +88,7 @@ gcc_package_group=(
 gcc_intel_pgi_package_group=(
   'neuronperfmodels@neuron'
   'coreneuron@perfmodels +mpi'
+  'coreneuron ~neurodamus +mpi'
   'neuronperfmodels@neuron +profile'
   'coreneuron@perfmodels +profile +mpi'
 )

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -5,8 +5,8 @@
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         packages=(
                 'mod2c'
-                'coreneuron ~neurodamusmod ~report'
-                'coreneuron ~neurodamusmod ~report ~mpi'
+                'coreneuron ~neurodamus ~report'
+                'coreneuron ~neurodamus ~report ~mpi'
                 'neuron@develop +python +shared ^python@3'
                 'neuron@develop +python +shared ^python@2.7'
                 'neuron@develop +python -shared ^python@2.7'
@@ -16,8 +16,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 # for PRs do minumum builds
 else
         packages=(
-                'coreneuron ~neurodamusmod ~report'
-                'coreneuron ~neurodamusmod ~report ~mpi'
+                'coreneuron ~neurodamus ~report'
+                'coreneuron ~neurodamus ~report ~mpi'
                 'neuron@develop +python +shared ^python@3'
                 'neuron@develop +python +shared ^python@2.7'
                 'neuron@develop +python -shared ^python@2.7'

--- a/packages/coreneuron/package.py
+++ b/packages/coreneuron/package.py
@@ -34,12 +34,12 @@ class Coreneuron(CMakePackage):
     version('checkpoint', git=url, branch='checkpoint-restart_prototype')
 
     # development version from bbp
-    version('hdf', git=bbpurl, branch='sandbox/kumbhar/nrnh5')
+    version('hdf',    git=bbpurl, branch='sandbox/kumbhar/nrnh5')
     version('devopt', git=bbpurl, branch='sandbox/kumbhar/dev')
 
     variant('mpi',           default=True,  description="Enable MPI support")
     variant('openmp',        default=True,  description="Enable OpenMP support")
-    variant('neurodamusmod', default=True,  description="Build only MOD files from Neurodamus")
+    variant('neurodamus',    default=True,  description="Build only MOD files from Neurodamus")
     variant('report',        default=True,  description="Enable reports using ReportingLib")
     variant('gpu',           default=False, description="Enable GPU build")
     variant('knl',           default=False, description="Enable KNL specific flags")
@@ -62,8 +62,8 @@ class Coreneuron(CMakePackage):
     depends_on('mod2c@checkpoint', type='build', when='@checkpoint')
 
     # granular dependency selection for neurodamus
-    depends_on('neurodamus@develop~compile', when='+neurodamusmod~gpu')
-    depends_on('neurodamus@gpu~compile', when='+gpu')
+    depends_on('neurodamus@coreneuron~special', when='+neurodamus~gpu')
+    depends_on('neurodamus@gpu~special', when='+gpu')
 
     # neuron models for benchmarking
     depends_on('neuronperfmodels@coreneuron', when='@perfmodels')
@@ -171,7 +171,7 @@ class Coreneuron(CMakePackage):
         if spec.satisfies('@perfmodels'):
             modlib_dir = self.nrnperf_modfiles
             mech_dir_set = True
-        elif spec.satisfies('+neurodamusmod'):
+        elif spec.satisfies('+neurodamus'):
             neurodamus_dir = self.spec['neurodamus'].prefix
             modlib_dir = '%s;%s/lib/modlib' % (modlib_dir, neurodamus_dir)
             modfile_list = '%s/lib/modlib/coreneuron_modlist.txt' % (neurodamus_dir)

--- a/packages/neurodamus/package.py
+++ b/packages/neurodamus/package.py
@@ -24,8 +24,8 @@ class Neurodamus(Package):
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
     url      = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
 
-    version('master',       git=url)
-    version('develop',      git=url, branch='coreneuronsetup')
+    version('master',       git=url, preferred=True)
+    version('coreneuron',   git=url, branch='coreneuronsetup')
     version('saveupdate',   git=url, branch='sandbox/king/saveupdate')
 
     # version being tested for incite
@@ -37,27 +37,28 @@ class Neurodamus(Package):
     version('simplification', git=url, branch='sandbox/roessert/MegaPaperCompatibility_simplification')
     version('parspike',     git=url, branch='sandbox/kumbhar/parspike')
 
-    variant('compile', default=True, description='Compile and create executable using nrnivmodl')
+    variant('special', default=True, description='Compile & create special using nrnivmodl')
     variant('profile', default=False, description="Enable profiling using Tau")
 
     # basic dependencies
-    depends_on("hdf5", when='+compile')
-    depends_on("zlib", when='+compile')
-    depends_on("neuron", when='+compile')
-    depends_on("mpi", when='+compile')
-    depends_on('reportinglib', when='+compile')
+    depends_on("hdf5", when='+special')
+    depends_on("zlib", when='+special')
+    depends_on("neuron", when='+special')
+    depends_on("neuron+coreneuron", when='@coreneuron')
+    depends_on("mpi", when='+special')
+    depends_on('reportinglib', when='+special')
 
     # when we want to profile
     depends_on('tau', when='+profile')
 
     # additional neuron version selections
-    depends_on("neuron+profile", when='+compile+profile')
+    depends_on("neuron+profile", when='+special+profile')
     # additional reportinglib selections
-    depends_on('reportinglib@gather', when='@saveupdateIO+compile')
-    depends_on('reportinglib+profile', when='+compile+profile')
+    depends_on('reportinglib@gather', when='@saveupdateIO+special')
+    depends_on('reportinglib+profile', when='+special+profile')
 
     # develop version is for coreneuron which needs neuron compiled with python
-    conflicts('^neuron~python', when='@develop+compile')
+    conflicts('^neuron~python', when='@develop+special')
 
     def profiling_wrapper_on(self):
         if self.spec.satisfies('+profile'):
@@ -71,7 +72,7 @@ class Neurodamus(Package):
         # copy lib directory containing modlib and hoclib
         shutil.copytree('lib', '%s/lib' % (prefix), symlinks=False)
 
-        if spec.satisfies('+compile'):
+        if spec.satisfies('+special'):
             with working_dir(prefix):
                 modlib = 'lib/modlib'
                 extra_flags = ''
@@ -96,13 +97,13 @@ class Neurodamus(Package):
 
     @run_after('install')
     def check_install(self):
-        if self.spec.satisfies('+compile'):
+        if self.spec.satisfies('+special'):
             # after install check if special is created
             special = '%s/special' % join_path(self.prefix, self.nrnarchdir)
             if not os.path.isfile(special):
                 raise RuntimeError("Neurodamus installion check failed!")
 
     def setup_environment(self, spack_env, run_env):
-        if self.spec.satisfies('+compile'):
+        if self.spec.satisfies('+special'):
             run_env.prepend_path('PATH', join_path(self.prefix, self.nrnarchdir))
             run_env.set('HOC_LIBRARY_PATH', join_path(self.prefix, 'lib/hoclib'))

--- a/packages/reportinglib/package.py
+++ b/packages/reportinglib/package.py
@@ -26,7 +26,7 @@ class Reportinglib(CMakePackage):
     version('develop', git=url, preferred=True)
 
     # temporary version for branch being tested for INCITE
-    version('gather', git=url, branch='sandbox/king/gatherMappingREP-31')
+    version('mapping', git=url, branch='sandbox/king/gatherMappingREP-31')
 
     variant('profile', default=False, description="Enable profiling using Tau")
     variant('static',  default=False, description="Build static library")


### PR DESCRIPTION
    Variants renaming for consistency:
     - neurodamus variant renamed from compile to special
     - neurodamusmod of coreneuron to neurodamus
     - saveupdate to plasticity
     - saveupdateIO to plasticitymapping
     - hippocampus version added
     - reportinglib version gather to mapping
     - removed unnecessary versions from coreneuron and neurodamus