### PR TITLE
Fix for NEURON on OS X with GCC compiler

### DIFF
--- a/packages/neuron/package.py
+++ b/packages/neuron/package.py
@@ -149,6 +149,11 @@ class Neuron(Package):
         if self.spec.satisfies('%pgi'):
             flags += ' ' + self.compiler.pic_flag
 
+        # NOTE for gcc build on OS X where setup.py uses clang
+        # specific flags during make install
+        env['CFLAGS'] = flags
+        env['CXXFLAGS'] = flags
+
         return ['CFLAGS=%s' % flags,
                 'CXXFLAGS=%s' % flags]
 


### PR DESCRIPTION
setup.py uses clang specific flags during make install
See #43 on github neuron