### PR TITLE
Fix python3 path for brew

### DIFF
--- a/.travis/packages.osx.yaml
+++ b/.travis/packages.osx.yaml
@@ -53,8 +53,8 @@ packages:
     python:
         paths:
             python@2.7.12: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
-        version: [2.7.12, 3.6.2]
+            python@3.6: /usr/local/opt/python3
+        version: [2.7.12, 3.6]
         buildable: False
     gsl:
         paths:

--- a/sysconfigs/mac/packages.yaml
+++ b/sysconfigs/mac/packages.yaml
@@ -75,9 +75,9 @@ packages:
     python:
         paths:
             python@2.7.10: /System/Library/Frameworks/Python.framework/Versions/2.7
-            python@3.6.2: /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6
+            python@3.6: /usr/local/opt/python3
         buildable: False
-        version: [2.7.10, 3.6.2]
+        version: [2.7.10, 3.6]
 
     hdf5:
         paths:


### PR DESCRIPTION
With brew python 3 minor versions change quite frequently.
Change path to /usr/local instead of full framework path.